### PR TITLE
Fix http import in ForgotPasswordModal

### DIFF
--- a/frontend/src/components/modals/ForgotPasswordModal.vue
+++ b/frontend/src/components/modals/ForgotPasswordModal.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref } from 'vue'
-import { http } from '@/services/http'
+import http from '@/services/http'
 
 const emit = defineEmits<{ (e:'close'):void }>()
 const email = ref('')


### PR DESCRIPTION
## Summary
- adjust import style for `http` service in ForgotPasswordModal

## Testing
- `npm install`
- `npm run build` *(fails: type errors in repo)*

------
https://chatgpt.com/codex/tasks/task_e_6840eb572b8c832a8c97c42c00d0fb21