### PR TITLE
Implement club management actions

### DIFF
--- a/frontend/src/services/dao/ClubDao.ts
+++ b/frontend/src/services/dao/ClubDao.ts
@@ -1,5 +1,5 @@
 import http from "@/services/http"
-import type { ClubDTO, ClubUpdateDTO } from "@/services/dao/models/Club.ts"
+import type { ClubDTO, ClubUpdateDTO, ClubSocialLinksDTO } from "@/services/dao/models/Club.ts"
 
 class ClubDao {
     async fetchAll(): Promise<ClubDTO[]> {
@@ -14,6 +14,24 @@ class ClubDao {
 
     async update(clubId: number, payload: ClubUpdateDTO): Promise<void> {
         await http.put(`/clubs/${clubId}`, payload)
+    }
+
+    async fetchHistory(clubId: number): Promise<any[]> {
+        const { data } = await http.get<any[]>(`/clubs/${clubId}/history`)
+        return data
+    }
+
+    async fetchAccessLog(clubId: number): Promise<any[]> {
+        const { data } = await http.get<any[]>(`/clubs/${clubId}/access-log`)
+        return data
+    }
+
+    async updateDetails(clubId: number, payload: ClubUpdateDTO): Promise<void> {
+        await http.put(`/clubs/${clubId}/details`, payload)
+    }
+
+    async updateSocialLinks(clubId: number, payload: ClubSocialLinksDTO): Promise<void> {
+        await http.put(`/clubs/${clubId}/social-links`, payload)
     }
 }
 

--- a/frontend/src/services/dao/models/Club.ts
+++ b/frontend/src/services/dao/models/Club.ts
@@ -13,3 +13,9 @@ export interface ClubUpdateDTO {
     group_status_id?: number
     group_category_id?: number
 }
+
+export interface ClubSocialLinksDTO {
+    facebook?: string
+    instagram?: string
+    twitter?: string
+}

--- a/frontend/src/store/useClubStore.ts
+++ b/frontend/src/store/useClubStore.ts
@@ -1,12 +1,14 @@
 // src/stores/useClubStore.ts
 import { defineStore } from 'pinia'
 import ClubDao from '@/services/dao/ClubDao'
-import type { ClubDTO, ClubUpdateDTO } from '@/services/dao/models/Club'
+import type { ClubDTO, ClubUpdateDTO, ClubSocialLinksDTO } from '@/services/dao/models/Club'
 
 export const useClubStore = defineStore('club', {
     state: () => ({
         list: [] as ClubDTO[],
         details: null as ClubDTO | null,
+        history: [] as any[],
+        accessLog: [] as any[],
         loading: false,
         error: null as string | null
     }),
@@ -31,11 +33,53 @@ export const useClubStore = defineStore('club', {
                 this.loading = false
             }
         },
+        async fetchHistory(id: number) {
+            this.loading = true; this.error = null
+            try {
+                this.history = await ClubDao.fetchHistory(id)
+            } catch (err: any) {
+                this.error = err.message
+            } finally {
+                this.loading = false
+            }
+        },
+        async fetchAccessLog(id: number) {
+            this.loading = true; this.error = null
+            try {
+                this.accessLog = await ClubDao.fetchAccessLog(id)
+            } catch (err: any) {
+                this.error = err.message
+            } finally {
+                this.loading = false
+            }
+        },
         async updateClub(id: number, payload: ClubUpdateDTO) {
             this.loading = true; this.error = null
             try {
                 await ClubDao.update(id, payload)
                 Object.assign(this.details, payload)
+            } catch (err: any) {
+                this.error = err.message
+            } finally {
+                this.loading = false
+            }
+        },
+        async updateDetails(id: number, payload: ClubUpdateDTO) {
+            this.loading = true; this.error = null
+            try {
+                await ClubDao.updateDetails(id, payload)
+                if (this.details) Object.assign(this.details, payload)
+            } catch (err: any) {
+                this.error = err.message
+            } finally {
+                this.loading = false
+            }
+        },
+        async updateSocialLinks(id: number, payload: ClubSocialLinksDTO) {
+            this.loading = true; this.error = null
+            try {
+                await ClubDao.updateSocialLinks(id, payload)
+                if (this.details) Object.assign(this.details, payload)
             } catch (err: any) {
                 this.error = err.message
             } finally {

--- a/frontend/src/views/club/Settings.vue
+++ b/frontend/src/views/club/Settings.vue
@@ -2,14 +2,14 @@
 import { onMounted } from 'vue'
 import { useRoute }   from 'vue-router'
 import { useClubStore } from '@/store/useClubStore'
+import { storeToRefs } from 'pinia'
 import LucideIcon from '@/components/ui/LucideIcon.vue'
 
 const clubStore = useClubStore()
 const route     = useRoute()
 const id        = Number(route.params.id)
 
-// extraemos con storeToRefs() si quieres
-// const { details, history, accessLog } = storeToRefs(clubStore)
+const { details, history, accessLog } = storeToRefs(clubStore)
 
 onMounted(() => {
   // solo a través del store
@@ -19,14 +19,14 @@ onMounted(() => {
 })
 
 function saveDetails() {
-  clubStore.updateDetails(id, clubStore.details)
+  clubStore.updateDetails(id, details.value)
 }
 
 function saveSocial() {
   clubStore.updateSocialLinks(id, {
-    facebook : clubStore.details.facebook,
-    instagram: clubStore.details.instagram,
-    twitter  : clubStore.details.twitter
+    facebook : details.value.facebook,
+    instagram: details.value.instagram,
+    twitter  : details.value.twitter
   })
 }
 </script>
@@ -36,19 +36,19 @@ function saveSocial() {
 
   <!-- Información del Club -->
   <div>
-    <input v-model="clubStore.details.name" … />
+    <input v-model="details.name" … />
     <!-- resto igual -->
     <button @click="saveDetails">Guardar cambios</button>
   </div>
 
   <!-- Redes Sociales -->
   <div>
-    <input v-model="clubStore.details.facebook" … />
+    <input v-model="details.facebook" … />
     <!-- resto igual -->
     <button @click="saveSocial">Guardar enlaces</button>
   </div>
 
   <!-- Historial y accesos -->
-  <div v-for="h in clubStore.history" :key="h.id">…</div>
-  <div v-for="r in clubStore.accessLog" :key="r.id">…</div>
+  <div v-for="h in history" :key="h.id">…</div>
+  <div v-for="r in accessLog" :key="r.id">…</div>
 </template>


### PR DESCRIPTION
## Summary
- extend ClubDao with history and social links endpoints
- handle club history and access log in the club store
- expose update helpers for club details and social links
- wire Settings view with new store methods

## Testing
- `pnpm run build` *(fails: vue-tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840f019c7a8832aa5a4d5c0f6b41894